### PR TITLE
Assert that signals send values of the expected type

### DIFF
--- a/ReactiveCocoaLayout/RACSignal+RCLGeometryAdditions.m
+++ b/ReactiveCocoaLayout/RACSignal+RCLGeometryAdditions.m
@@ -106,6 +106,8 @@ static RACSignal *latestNumberMatchingComparisonResult(NSArray *signals, NSCompa
 			if (previous == nil) return next;
 			if (next == nil) return previous;
 
+			NSCAssert([next isKindOfClass:NSNumber.class], @"Value sent is not a number: %@", next);
+
 			if ([previous compare:next] == result) {
 				return next;
 			} else {


### PR DESCRIPTION
Otherwise, it's really easy to get struct garbage from `NSValue`s.
