### PR TITLE
Add RCLBox() macro for creating a signal with a constant value

### DIFF
--- a/Demos/DeviceRotation/DeviceRotation/ViewController.m
+++ b/Demos/DeviceRotation/DeviceRotation/ViewController.m
@@ -52,7 +52,7 @@
 
 	// Purposely misaligned to demonstrate automatic pixel alignment when
 	// binding to RCL's UIView properties.
-	RACSignal *insetRect = [self.view.rcl_boundsSignal insetWidth:RCL(16.25) height:RCL(24.75)];
+	RACSignal *insetRect = [self.view.rcl_boundsSignal insetWidth:RCLBox(16.25) height:RCLBox(24.75)];
 
 	// Dynamically change the text of nameLabel based on the current
 	// orientation.
@@ -62,10 +62,10 @@
 
 	// Horizontally divide the available space into a rect for the label and
 	// a rect for the text field.
-	RACTupleUnpack(RACSignal *labelRect, RACSignal *textFieldRect) = [insetRect divideWithAmount:self.nameLabel.rcl_intrinsicWidthSignal padding:RCL(8) fromEdge:NSLayoutAttributeLeading];
+	RACTupleUnpack(RACSignal *labelRect, RACSignal *textFieldRect) = [insetRect divideWithAmount:self.nameLabel.rcl_intrinsicWidthSignal padding:RCLBox(8) fromEdge:NSLayoutAttributeLeading];
 
 	// Make the text field a constant 28 points high.
-	textFieldRect = [textFieldRect sliceWithAmount:RCL(28) fromEdge:NSLayoutAttributeTop];
+	textFieldRect = [textFieldRect sliceWithAmount:RCLBox(28) fromEdge:NSLayoutAttributeTop];
 
 	// Size the label to its intrinsic size, and align it to the text field.
 	//

--- a/Demos/ResizingWindow/ResizingWindow/ResizingWindowController.m
+++ b/Demos/ResizingWindow/ResizingWindow/ResizingWindowController.m
@@ -44,11 +44,11 @@
 }
 
 - (RACSignal *)horizontalPadding {
-	return RCL(8);
+	return RCLBox(8);
 }
 
 - (RACSignal *)verticalPadding {
-	return RCL(8);
+	return RCLBox(8);
 }
 
 #pragma mark Lifecycle
@@ -97,7 +97,7 @@
 	RACTupleUnpack(RACSignal *emailRect, RACSignal *possibleConfirmEmailRect) = [[self.contentView.rcl_frameSignal
 		// Purposely misaligned to demonstrate automatic pixel alignment when
 		// binding to RCL's NSView properties.
-		insetWidth:RCL(32.25) height:RCL(16.75)]
+		insetWidth:RCLBox(32.25) height:RCLBox(16.75)]
 		divideWithAmount:self.emailField.rcl_intrinsicHeightSignal padding:self.verticalPadding fromEdge:NSLayoutAttributeTop];
 
 	[self layoutField:self.emailField label:self.emailLabel fromSignal:emailRect];

--- a/ReactiveCocoaLayout/RCLMacros.h
+++ b/ReactiveCocoaLayout/RCLMacros.h
@@ -12,7 +12,7 @@
 // integral type, floating-point type, or a Core Graphics geometry structure.
 //
 // Returns a RACSignal.
-#define RCL(VALUE) RCLBox(VALUE)
+#define RCLBox(VALUE) RCLBox(VALUE)
 
 // Binds a view's frame to a set of attributes which describe different parts of
 // the frame rectangle.

--- a/ReactiveCocoaLayoutTests/RCLMacrosSpec.m
+++ b/ReactiveCocoaLayoutTests/RCLMacrosSpec.m
@@ -770,64 +770,64 @@ describe(@"RCLAlignment", ^{
 	});
 });
 
-describe(@"RCL", ^{
+describe(@"RCLBox", ^{
 	it(@"should create a constant signal of int", ^{
-		RACSignal *signal = RCL(INT_MIN);
+		RACSignal *signal = RCLBox(INT_MIN);
 		expect([signal toArray]).to.equal(@[ @(INT_MIN) ]);
 	});
 
 	it(@"should create a constant signal of unsigned int", ^{
-		RACSignal *signal = RCL(UINT_MAX);
+		RACSignal *signal = RCLBox(UINT_MAX);
 		expect([signal toArray]).to.equal(@[ @(UINT_MAX) ]);
 	});
 
 	it(@"should create a constant signal of long long", ^{
-		RACSignal *signal = RCL(LLONG_MIN);
+		RACSignal *signal = RCLBox(LLONG_MIN);
 		expect([signal toArray]).to.equal(@[ @(LLONG_MIN) ]);
 	});
 
 	it(@"should create a constant signal of unsigned long long", ^{
-		RACSignal *signal = RCL(ULLONG_MAX);
+		RACSignal *signal = RCLBox(ULLONG_MAX);
 		expect([signal toArray]).to.equal(@[ @(ULLONG_MAX) ]);
 	});
 
 	it(@"should create a constant signal of signed char", ^{
 		signed char value = SCHAR_MIN;
-		RACSignal *signal = RCL(value);
+		RACSignal *signal = RCLBox(value);
 		expect([signal toArray]).to.equal(@[ @(value) ]);
 	});
 
 	it(@"should create a constant signal of unsigned char", ^{
 		unsigned char value = UCHAR_MAX;
-		RACSignal *signal = RCL(value);
+		RACSignal *signal = RCLBox(value);
 		expect([signal toArray]).to.equal(@[ @(value) ]);
 	});
 
 	it(@"should create a constant signal of float", ^{
-		RACSignal *signal = RCL(FLT_MAX);
+		RACSignal *signal = RCLBox(FLT_MAX);
 		expect([signal toArray]).to.equal(@[ @(FLT_MAX) ]);
 	});
 
 	it(@"should create a constant signal of double", ^{
-		RACSignal *signal = RCL(DBL_MAX);
+		RACSignal *signal = RCLBox(DBL_MAX);
 		expect([signal toArray]).to.equal(@[ @(DBL_MAX) ]);
 	});
 
 	it(@"should create a constant signal of CGRect", ^{
 		CGRect rect = CGRectMake(1, 2, 3, 4);
-		RACSignal *signal = RCL(rect);
+		RACSignal *signal = RCLBox(rect);
 		expect([signal toArray]).to.equal(@[ [NSValue med_valueWithRect:rect] ]);
 	});
 
 	it(@"should create a constant signal of CGSize", ^{
 		CGSize size = CGSizeMake(5, 10);
-		RACSignal *signal = RCL(size);
+		RACSignal *signal = RCLBox(size);
 		expect([signal toArray]).to.equal(@[ [NSValue med_valueWithSize:size] ]);
 	});
 
 	it(@"should create a constant signal of CGPoint", ^{
 		CGPoint point = CGPointMake(5, 10);
-		RACSignal *signal = RCL(point);
+		RACSignal *signal = RCLBox(point);
 		expect([signal toArray]).to.equal(@[ [NSValue med_valueWithPoint:point] ]);
 	});
 });


### PR DESCRIPTION
Requested by @alanjrogers for expressions like:
- `RCLBox(5)` instead of `[RACSignal return:@5]`
- `RCLBox(value)` instead of `[RACSignal return:@(value)]`
- `RCLBox(CGSizeMake(2, 3))` instead of `[RACSignal return:MEDBox(CGSizeMake(2, 3))]` – or, without [Archimedes](https://github.com/github/Archimedes), `[RACSignal return:[NSValue valueWithSize:CGSizeMake(2, 3)]]`

~~Based on the implementation of [MEDBox](https://github.com/github/Archimedes/blob/92e3bf36d1a5a28a3c23c428192b70742de01ed0/Archimedes/NSValue%2BMEDGeometryAdditions.h#L11-L24).~~
