### PR TITLE
fixes for refs to 1.9 RAC stuff

### DIFF
--- a/ReactiveCocoaLayout/NSCell+RCLGeometryAdditions.m
+++ b/ReactiveCocoaLayout/NSCell+RCLGeometryAdditions.m
@@ -9,7 +9,7 @@
 #import "NSCell+RCLGeometryAdditions.h"
 #import "NSControl+RCLGeometryAdditions.h"
 #import <Archimedes/Archimedes.h>
-#import <ReactiveCocoa/EXTScope.h>
+#import <ReactiveCocoa/RACEXTScope.h>
 #import <ReactiveCocoa/ReactiveCocoa.h>
 
 // Returns a signal which sends the given cell once immediately, and then again

--- a/ReactiveCocoaLayout/NSView+RCLGeometryAdditions.m
+++ b/ReactiveCocoaLayout/NSView+RCLGeometryAdditions.m
@@ -12,7 +12,7 @@
 #import "View+RCLAutoLayoutAdditions.h"
 #import <Archimedes/Archimedes.h>
 #import <objc/runtime.h>
-#import <ReactiveCocoa/EXTScope.h>
+#import <ReactiveCocoa/RACEXTScope.h>
 #import <ReactiveCocoa/ReactiveCocoa.h>
 
 @implementation NSView (RCLGeometryAdditions)

--- a/ReactiveCocoaLayout/RACSignal+RCLAnimationAdditions.m
+++ b/ReactiveCocoaLayout/RACSignal+RCLAnimationAdditions.m
@@ -8,7 +8,7 @@
 
 #import "RACSignal+RCLAnimationAdditions.h"
 #import <libkern/OSAtomic.h>
-#import <ReactiveCocoa/EXTScope.h>
+#import <ReactiveCocoa/RACEXTScope.h>
 
 // The number of animated signals in the current chain.
 //

--- a/ReactiveCocoaLayout/RCLMacros.m
+++ b/ReactiveCocoaLayout/RCLMacros.m
@@ -8,7 +8,7 @@
 
 #import "RCLMacros.h"
 #import "RACSignal+RCLGeometryAdditions.h"
-#import <ReactiveCocoa/EXTScope.h>
+#import <ReactiveCocoa/RACEXTScope.h>
 
 #ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
 #import "UIView+RCLGeometryAdditions.h"

--- a/ReactiveCocoaLayout/View+RCLAutoLayoutAdditions.m
+++ b/ReactiveCocoaLayout/View+RCLAutoLayoutAdditions.m
@@ -10,7 +10,7 @@
 #import "RACSignal+RCLGeometryAdditions.h"
 #import <Archimedes/Archimedes.h>
 #import <objc/runtime.h>
-#import <ReactiveCocoa/EXTScope.h>
+#import <ReactiveCocoa/RACEXTScope.h>
 #import <ReactiveCocoa/ReactiveCocoa.h>
 
 #ifdef __IPHONE_OS_VERSION_MIN_REQUIRED


### PR DESCRIPTION
`EXTScope.h` no longer exists within ReactiveCocoa. Apparently it's been replaced by `RACEXTScope.h`. A bit confusing because this change isn't noted in the [changelog](https://github.com/ReactiveCocoa/ReactiveCocoa/blob/master/CHANGELOG.md).
