### PR TITLE
Work around weird AppKit animation deadlock

### DIFF
--- a/ReactiveCocoaLayout/RACSignal+RCLAnimationAdditions.m
+++ b/ReactiveCocoaLayout/RACSignal+RCLAnimationAdditions.m
@@ -87,7 +87,11 @@ static RACSignal *animatedSignalsWithDuration (RACSignal *self, NSNumber *durati
 
 					[subscriber sendNext:value];
 				} completionHandler:^{
-					[subscriber sendCompleted];
+					// Avoids weird AppKit deadlocks when interrupting an
+					// existing animation.
+					[RACScheduler.mainThreadScheduler schedule:^{
+						[subscriber sendCompleted];
+					}];
 				}];
 			#endif
 


### PR DESCRIPTION
There's apparently some spinlock in `+[NSAnimationContext endGrouping]` that gets rustled if we start another animation from within a completion handler.
