### PR TITLE
Publish the bindings signals for general use.

### DIFF
--- a/ReactiveCocoaLayout/RCLMacros.h
+++ b/ReactiveCocoaLayout/RCLMacros.h
@@ -141,6 +141,16 @@
 // always relative to views' alignment rectangles.
 #define rcl_baseline @(RCLAttributeBaseline)
 
+@interface RACSignal (RCLBindings)
+
+/// Constructs rects using the given dictionary of signals. cf `RCLFrame`
+/// and `RCLAlignment` for the semantics of this dictionary.
+///
+/// This simplifies the creation of race-free dependent layouts.
++ (RACSignal *)rectsWithView:(id)view bindings:(NSDictionary *)bindings;
+
+@end
+
 @interface RCLRectAssignmentTrampoline : NSObject
 
 #ifdef __IPHONE_OS_VERSION_MIN_REQUIRED

--- a/ReactiveCocoaLayout/RCLMacros.m
+++ b/ReactiveCocoaLayout/RCLMacros.m
@@ -67,17 +67,19 @@ static NSString *NSStringFromRCLAttribute(RCLAttribute attribute) __attribute__(
 	NSParameterAssert(property != nil);
 	NSParameterAssert([bindings isKindOfClass:NSDictionary.class]);
 
-	[[self rectSignalFromBindings:bindings] setKeyPath:property onObject:self.view];
+	[[RACSignal rectsWithView:self.view bindings:bindings] setKeyPath:property onObject:self.view];
 }
 
-#pragma mark Attribute Parsing
+@end
 
-- (RACSignal *)rectSignalFromBindings:(NSDictionary *)bindings {
+@implementation RACSignal (RCLBindings)
+
++ (RACSignal *)rectsWithView:(id)view bindings:(NSDictionary *)bindings {
 	NSParameterAssert(bindings != nil);
 
 	NSArray *sortedAttributes = [bindings.allKeys sortedArrayUsingSelector:@selector(compare:)];
 
-	RACSignal *signal = [self.view rcl_intrinsicBoundsSignal];
+	RACSignal *signal = [view rcl_intrinsicBoundsSignal];
 	for (NSNumber *attribute in sortedAttributes) {
 		NSAssert([attribute isKindOfClass:NSNumber.class], @"Layout binding key is not a RCLAttribute: %@", attribute);
 
@@ -158,7 +160,7 @@ static NSString *NSStringFromRCLAttribute(RCLAttribute attribute) __attribute__(
 					}]
 					switchToLatest];
 
-				signal = [signal alignBaseline:[self.view rcl_baselineSignal] toBaseline:referenceBaseline ofRect:referenceRect];
+				signal = [signal alignBaseline:[view rcl_baselineSignal] toBaseline:referenceBaseline ofRect:referenceRect];
 				break;
 			}
 		}
@@ -167,7 +169,7 @@ static NSString *NSStringFromRCLAttribute(RCLAttribute attribute) __attribute__(
 	return signal;
 }
 
-- (RACSignal *)signalWithConstantValue:(id)value forAttribute:(RCLAttribute)attribute {
++ (RACSignal *)signalWithConstantValue:(id)value forAttribute:(RCLAttribute)attribute {
 	NSParameterAssert(value != nil);
 
 	switch (attribute) {


### PR DESCRIPTION
This is a simple PR, basically just exposing the mechanism for creating a signal from a dictionary of bindings for general use.

The motivating case was a situation where the frames of a view depended on another view, the first also having been laid out with `RCLFrame`, and this introduced a race condition between the signal setting the frame and the signal retrieving the frame. It was (generally) recoverable, but introduced needless churn into the layout, and otherwise looked glitchy.
